### PR TITLE
configure unittests and linter for go bindings

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,3 +13,5 @@ component-spec:
         render_and_update_documentation:
           publish_to: ['github_pages']
         run-unittests: ~
+        run-golang-check:
+          image: golang:1.14-alpine

--- a/.ci/run-golang-check
+++ b/.ci/run-golang-check
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+own_dir="$(readlink -f "$(dirname "${0}")")"
+repo_root="$(readlink -f "${own_dir}/..")"
+
+cd ${repo_root}/bindings-go/
+
+make install-requirements
+go mod vendor
+
+make check
+make test
+
+echo "All checks succeeded"

--- a/bindings-go/Makefile
+++ b/bindings-go/Makefile
@@ -12,16 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: install-requirements
 install-requirements:
-	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
-	@go get -u github.com/go-bindata/go-bindata/...
+	@$(REPO_ROOT)/hack/install-requirements.sh
 
 .PHONY: format
 format:
-	@$(REPO_ROOT)/hack/format.sh $(REPO_ROOT)/
+	@$(REPO_ROOT)/hack/format.sh $(REPO_ROOT)/apis $(REPO_ROOT)/codec $(REPO_ROOT)/examples
+
+.PHONY: test
+test:
+	@go test $(REPO_ROOT)/...
+
+.PHONY: check
+check:
+	@echo "Run lint"; golangci-lint run --timeout 10m $(REPO_ROOT)/...
+	@$(REPO_ROOT)/hack/check.sh $(REPO_ROOT)/apis $(REPO_ROOT)/codec $(REPO_ROOT)/examples
 
 .PHONY: revendor
 revendor:

--- a/bindings-go/go.mod
+++ b/bindings-go/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/qri-io/jsonschema v0.2.0

--- a/bindings-go/go.sum
+++ b/bindings-go/go.sum
@@ -14,6 +14,9 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-bindata/go-bindata v1.0.0 h1:DZ34txDXWn1DyWa+vQf7V9ANc2ILTtrEjtlsdJRF26M=
+github.com/go-bindata/go-bindata v3.1.2+incompatible h1:5vjJMVhowQdPzjE1LdxyFF7YFTXg5IgGVW4gBr5IbvE=
+github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=

--- a/bindings-go/hack/check.sh
+++ b/bindings-go/hack/check.sh
@@ -16,6 +16,14 @@
 
 set -e
 
-echo "> Format"
+echo "> Check"
 
-goimports -l -w --local github.com/gardener/component-spec $@
+echo "Check generated files"
+unformatted_files="$(goimports -l --local github.com/gardener/component-spec $@)"
+if [[ "$unformatted_files" ]]; then
+  echo "Unformatted files:"
+  echo "$unformatted_files"
+  exit 1
+fi
+
+echo "Checks succeeded"

--- a/bindings-go/hack/install-requirements.sh
+++ b/bindings-go/hack/install-requirements.sh
@@ -16,6 +16,8 @@
 
 set -e
 
-echo "> Format"
+echo "> Install requirements"
 
-goimports -l -w --local github.com/gardener/component-spec $@
+GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+GO111MODULE=on curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+go get -u github.com/go-bindata/go-bindata/...


### PR DESCRIPTION
**What this PR does / why we need it**:
Configures a pipline that runs linter, formatter and unittest execution for the go bindings.

@ccwienk I added an additional pipeline step to be able to use the golang image. 
Alternatively, I could add a `golang_unittest` function to `.ci/run-unittest` which mean that I would then need to install go first. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
