### PR TITLE
Add labels and component name to go binding

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,7 +14,7 @@ component-spec:
           publish_to: ['github_pages']
         run-unittests: ~
         run-golang-check:
-          image: golang:1.14-alpine
+          image: golang:1.14
     release:
       traits:
         component_descriptor: ~

--- a/bindings-go/apis/v2/componentdescriptor.go
+++ b/bindings-go/apis/v2/componentdescriptor.go
@@ -64,7 +64,7 @@ type ComponentSpec struct {
 	// Sources defines sources that produced the component
 	Sources []Resource `json:"sources"`
 	// ComponentReferences references component dependencies that can be resolved in the current context.
-	ComponentReferences []ObjectMeta `json:"componentReferences"`
+	ComponentReferences []ComponentReference `json:"componentReferences"`
 	// LocalResources defines internal resources that are created by the component
 	LocalResources []Resource `json:"localResources"`
 	// ExternalResources defines external resources that are not produced by a third party.
@@ -79,12 +79,24 @@ type RepositoryContext struct {
 	BaseURL string `json:"baseUrl"`
 }
 
+// Label is a label that can be set on objects.
+type Label struct {
+	// Name is the unique name of the label.
+	Name string `json:"name"`
+	// Value is the json/yaml data of the label
+	Value json.RawMessage `json:"value"`
+}
+
 // ObjectMeta defines a object that is uniquely identified by its name and version.
 type ObjectMeta struct {
 	// Name is the context unique name of the object.
 	Name string `json:"name"`
 	// Version is the semver version of the object.
 	Version string `json:"version"`
+	// Labels defines an optional set of additional labels
+	// describing the object.
+	// +optional
+	Labels []Label `json:"labels,omitempty"`
 }
 
 // GetName returns the name of the object.
@@ -105,6 +117,16 @@ func (o ObjectMeta) GetVersion() string {
 // SetVersion sets the version of the object.
 func (o *ObjectMeta) SetVersion(version string) {
 	o.Version = version
+}
+
+// GetLabels returns the label of the object.
+func (o ObjectMeta) GetLabels() []Label {
+	return o.Labels
+}
+
+// SetLabels sets the labels of the object.
+func (o *ObjectMeta) SetLabels(labels []Label) {
+	o.Labels = labels
 }
 
 // ObjectType describes the type of a object
@@ -132,6 +154,10 @@ type ObjectMetaAccessor interface {
 	GetVersion() string
 	// SetVersion sets the version of the access object.
 	SetVersion(version string)
+	// GetLabels returns the labels of the access object.
+	GetLabels() string
+	// SetLabels sets the labels of the access object.
+	SetLabels(labels []Label)
 }
 
 // AccessAccessor defines the accessor for a component
@@ -144,6 +170,13 @@ type AccessAccessor interface {
 	GetData() ([]byte, error)
 	// SetData sets the custom data of a component.
 	SetData([]byte) error
+}
+
+// ComponentReference describes the reference to another component in the registry.
+type ComponentReference struct {
+	ObjectMeta `json:",inline"`
+	// ComponentName describes the remote name of the referenced object
+	ComponentName string `json:"componentName"`
 }
 
 // Resource describes a resource dependency of a component.

--- a/bindings-go/apis/v2/constants.go
+++ b/bindings-go/apis/v2/constants.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+// ComponentDescriptorOCIMediaType is the media type containing the tared component descriptor in an oci registry.
+const ComponentDescriptorOCIMediaType = "application/sap-cnudie+tar"
+
+// ComponentDescriptorOCIFileName is the name of the file in the tar.
+const ComponentDescriptorOCIFileName = "component-descriptor.yaml"

--- a/bindings-go/apis/v2/default.go
+++ b/bindings-go/apis/v2/default.go
@@ -20,7 +20,7 @@ func DefaultComponent(component *ComponentDescriptor) error {
 		component.Sources = make([]Resource, 0)
 	}
 	if component.ComponentReferences == nil {
-		component.ComponentReferences = make([]ObjectMeta, 0)
+		component.ComponentReferences = make([]ComponentReference, 0)
 	}
 	if component.LocalResources == nil {
 		component.LocalResources = make([]Resource, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds labels and the component name to the go binding of the component descriptor.

Also added the oci media type and component descriptor filename as constants.

**Special notes for your reviewer**:

/invite @Diaphteiros 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
