### PR TITLE
Fix test and add github type

### DIFF
--- a/bindings-go/apis/v2/accesstypes.go
+++ b/bindings-go/apis/v2/accesstypes.go
@@ -111,6 +111,53 @@ var webCodec = &AccessCodecWrapper{
 	}),
 }
 
+// WebType is the type of a web component
+const GitHubAccessType = "github"
+
+// GitHubAccess describes a github respository resource access.
+type GitHubAccess struct {
+	ObjectType `json:",inline"`
+
+	// RepoURL is the url pointing to the remote repository.
+	RepoURL string `json:"repoUrl"`
+	// Ref describes the git reference.
+	Ref string `json:"ref"`
+}
+
+var _ AccessAccessor = &GitHubAccess{}
+
+func (w GitHubAccess) GetData() ([]byte, error) {
+	return yaml.Marshal(w)
+}
+
+func (w *GitHubAccess) SetData(bytes []byte) error {
+	var newGitHubAccess GitHubAccess
+	if err := json.Unmarshal(bytes, &newGitHubAccess); err != nil {
+		return err
+	}
+
+	w.RepoURL = newGitHubAccess.RepoURL
+	w.Ref = newGitHubAccess.Ref
+	return nil
+}
+
+var githubAccessCodec = &AccessCodecWrapper{
+	AccessDecoder: AccessDecoderFunc(func(data []byte) (AccessAccessor, error) {
+		var github GitHubAccess
+		if err := json.Unmarshal(data, &github); err != nil {
+			return nil, err
+		}
+		return &github, nil
+	}),
+	AccessEncoder: AccessEncoderFunc(func(accessor AccessAccessor) ([]byte, error) {
+		github, ok := accessor.(*GitHubAccess)
+		if !ok {
+			return nil, fmt.Errorf("accessor is not of type %s", OCIImageType)
+		}
+		return json.Marshal(github)
+	}),
+}
+
 // CustomAccess describes a generic dependency of a resolvable component.
 type CustomAccess struct {
 	ObjectType `json:",inline"`

--- a/bindings-go/apis/v2/codecs.go
+++ b/bindings-go/apis/v2/codecs.go
@@ -21,8 +21,9 @@ import (
 
 // KnownAccessTypes contains all known access serializer
 var KnownAccessTypes = map[string]AccessCodec{
-	OCIRegistryType: ociCodec,
-	WebType:         webCodec,
+	OCIRegistryType:  ociCodec,
+	GitHubAccessType: githubAccessCodec,
+	WebType:          webCodec,
 }
 
 // AccessCodec describes a known component type and how it is decoded and encoded
@@ -64,7 +65,7 @@ func (e AccessEncoderFunc) Encode(accessor AccessAccessor) ([]byte, error) {
 }
 
 // ValidateAccessType validates that a type is known or of a generic type.
-// todo: revisit currently "x-" specifies a generic type
+// todo: revisit; currently "x-" specifies a generic type
 func ValidateAccessType(ttype string) error {
 	if _, ok := KnownAccessTypes[ttype]; ok {
 		return nil

--- a/bindings-go/apis/v2/resources.go
+++ b/bindings-go/apis/v2/resources.go
@@ -14,5 +14,8 @@
 
 package v2
 
-// OCIImageType is the type of an oci image component
+// OCIImageType is the type of an oci image component.
 const OCIImageType = "ociImage"
+
+// GitType is the type a git repository resource.
+const GitType = "git"

--- a/bindings-go/codec/codec_suite_test.go
+++ b/bindings-go/codec/codec_suite_test.go
@@ -33,7 +33,7 @@ func TestConfig(t *testing.T) {
 var _ = Describe("serializer", func() {
 
 	It("should decode a simple component", func() {
-		data, err := ioutil.ReadFile("./testdata/01-data.yaml")
+		data, err := ioutil.ReadFile("../../language-independent/test-resources/component_descriptor_v2.yaml")
 		Expect(err).ToNot(HaveOccurred())
 
 		var comp v2.ComponentDescriptor
@@ -45,10 +45,13 @@ var _ = Describe("serializer", func() {
 		Expect(comp.ExternalResources).To(HaveLen(1))
 
 		extDep := comp.ExternalResources[0]
-		Expect(extDep.Name).To(Equal("hyperkube"))
-		Expect(extDep.Version).To(Equal("v1.16.4"))
+		Expect(extDep.Name).To(Equal("grafana"))
+		Expect(extDep.Version).To(Equal("7.0.3"))
 		Expect(extDep.Type).To(Equal(v2.OCIImageType))
 		Expect(extDep.Access).To(BeAssignableToTypeOf(&v2.OCIRegistryAccess{}))
+
+		ociAccess := extDep.Access.(*v2.OCIRegistryAccess)
+		Expect(ociAccess.ImageReference).To(Equal("registry-1.docker.io/grafana/grafana/7.0.3"))
 	})
 
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The go test now also uses the shared example.
Added github as possible access type.

Currently the test still fails because of a required version in the sources:
```
should decode a simple component [It]
  /Users/d064999/go/src/github.com/gardener/component-spec/bindings-go/codec/codec_suite_test.go:35

  Unexpected error:
      <errors.aggregate | len:1, cap:1>: [
          {
              Type: "FieldValueRequired",
              Field: "component.sources[0].version",
              BadValue: "",
              Detail: "must specify a version",
          },
      ]
      component.sources[0].version: Required value: must specify a version
  occurred
```

/hold

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
