### PR TITLE
Fix go bindings and allow additional type attributes

### DIFF
--- a/bindings-go/apis/v2/codecs.go
+++ b/bindings-go/apis/v2/codecs.go
@@ -19,48 +19,47 @@ import (
 	"strings"
 )
 
-// KnownAccessTypes contains all known access serializer
-var KnownAccessTypes = map[string]AccessCodec{
-	OCIRegistryType:  ociCodec,
-	GitHubAccessType: githubAccessCodec,
-	WebType:          webCodec,
+// KnownTypes defines a set of known types.
+type KnownTypes map[string]TypedObjectCodec
+
+// KnownTypeValidationFunc defines a function that can optionally validate types.
+type KnownTypeValidationFunc func(ttype string) error
+
+// TypedObjectCodec describes a known component type and how it is decoded and encoded
+type TypedObjectCodec interface {
+	TypedObjectDecoder
+	TypedObjectEncoder
 }
 
-// AccessCodec describes a known component type and how it is decoded and encoded
-type AccessCodec interface {
-	AccessDecoder
-	AccessEncoder
+// TypedObjectCodecWrapper is a simple struct that implements the TypedObjectCodec interface
+type TypedObjectCodecWrapper struct {
+	TypedObjectDecoder
+	TypedObjectEncoder
 }
 
-// AccessCodecWrapper is a simple struct that implements the AccessCodec interface
-type AccessCodecWrapper struct {
-	AccessDecoder
-	AccessEncoder
+// TypedObjectDecoder defines a decoder for a typed object.
+type TypedObjectDecoder interface {
+	Decode(data []byte) (TypedObjectAccessor, error)
 }
 
-// AccessDecoder decodes a component dependency.
-type AccessDecoder interface {
-	Decode(data []byte) (AccessAccessor, error)
+// TypedObjectEncoder defines a encoder for a typed object.
+type TypedObjectEncoder interface {
+	Encode(accessor TypedObjectAccessor) ([]byte, error)
 }
 
-// AccessEncoder encodes a component dependency.
-type AccessEncoder interface {
-	Encode(accessor AccessAccessor) ([]byte, error)
-}
+// TypedObjectDecoderFunc is a simple function that implements the TypedObjectDecoder interface.
+type TypedObjectDecoderFunc func(data []byte) (TypedObjectAccessor, error)
 
-// AccessDecoderFunc is a simple function that implements the AccessDecoder interface.
-type AccessDecoderFunc func(data []byte) (AccessAccessor, error)
-
-// Decode is the Decode implementation of the AccessDecoder interface.
-func (e AccessDecoderFunc) Decode(data []byte) (AccessAccessor, error) {
+// Decode is the Decode implementation of the TypedObjectDecoder interface.
+func (e TypedObjectDecoderFunc) Decode(data []byte) (TypedObjectAccessor, error) {
 	return e(data)
 }
 
-// AccessEncoderFunc is a simple function that implements the AccessEncoder interface.
-type AccessEncoderFunc func(accessor AccessAccessor) ([]byte, error)
+// TypedObjectEncoderFunc is a simple function that implements the TypedObjectEncoder interface.
+type TypedObjectEncoderFunc func(accessor TypedObjectAccessor) ([]byte, error)
 
-// Encode is the Encode implementation of the AccessEncoder interface.
-func (e AccessEncoderFunc) Encode(accessor AccessAccessor) ([]byte, error) {
+// Encode is the Encode implementation of the TypedObjectEncoder interface.
+func (e TypedObjectEncoderFunc) Encode(accessor TypedObjectAccessor) ([]byte, error) {
 	return e(accessor)
 }
 

--- a/bindings-go/apis/v2/componentdescriptor.go
+++ b/bindings-go/apis/v2/componentdescriptor.go
@@ -62,9 +62,9 @@ type ComponentSpec struct {
 	// It can be external or internal.
 	Provider ProviderType `json:"provider"`
 	// Sources defines sources that produced the component
-	Sources []Resource `json:"sources"`
+	Sources []Source `json:"sources"`
 	// ComponentReferences references component dependencies that can be resolved in the current context.
-	ComponentReferences []ComponentReference `json:"componentReferences"`
+	ComponentReferences []ObjectMeta `json:"componentReferences"`
 	// LocalResources defines internal resources that are created by the component
 	LocalResources []Resource `json:"localResources"`
 	// ExternalResources defines external resources that are not produced by a third party.
@@ -79,24 +79,12 @@ type RepositoryContext struct {
 	BaseURL string `json:"baseUrl"`
 }
 
-// Label is a label that can be set on objects.
-type Label struct {
-	// Name is the unique name of the label.
-	Name string `json:"name"`
-	// Value is the json/yaml data of the label
-	Value json.RawMessage `json:"value"`
-}
-
 // ObjectMeta defines a object that is uniquely identified by its name and version.
 type ObjectMeta struct {
 	// Name is the context unique name of the object.
 	Name string `json:"name"`
 	// Version is the semver version of the object.
 	Version string `json:"version"`
-	// Labels defines an optional set of additional labels
-	// describing the object.
-	// +optional
-	Labels []Label `json:"labels,omitempty"`
 }
 
 // GetName returns the name of the object.
@@ -119,16 +107,6 @@ func (o *ObjectMeta) SetVersion(version string) {
 	o.Version = version
 }
 
-// GetLabels returns the label of the object.
-func (o ObjectMeta) GetLabels() []Label {
-	return o.Labels
-}
-
-// SetLabels sets the labels of the object.
-func (o *ObjectMeta) SetLabels(labels []Label) {
-	o.Labels = labels
-}
-
 // ObjectType describes the type of a object
 type ObjectType struct {
 	// Type describes the type of the object.
@@ -145,23 +123,30 @@ func (t *ObjectType) SetType(ttype string) {
 	t.Type = ttype
 }
 
-type ObjectMetaAccessor interface {
-	// GetName returns the name of the access object.
+// NameAccessor describes a accessor for a named object.
+type NameAccessor interface {
+	// GetName returns the name of the object.
 	GetName() string
-	// SetName sets the name of the access object.
+	// SetName sets the name of the object.
 	SetName(name string)
-	// GetVersion returns the version of the access object.
-	GetVersion() string
-	// SetVersion sets the version of the access object.
-	SetVersion(version string)
-	// GetLabels returns the labels of the access object.
-	GetLabels() string
-	// SetLabels sets the labels of the access object.
-	SetLabels(labels []Label)
 }
 
-// AccessAccessor defines the accessor for a component
-type AccessAccessor interface {
+// VersionAccessor describes a accessor for a versioned object.
+type VersionAccessor interface {
+	// GetVersion returns the version of the object.
+	GetVersion() string
+	// SetVersion sets the version of the object.
+	SetVersion(version string)
+}
+
+// ObjectMetaAccessor describes a accessor for named and versioned object.
+type ObjectMetaAccessor interface {
+	NameAccessor
+	VersionAccessor
+}
+
+// TypedObjectAccessor defines the accessor for a typed component with additional data.
+type TypedObjectAccessor interface {
 	// GetType returns the type of the access object.
 	GetType() string
 	// SetType sets the type of the access object.
@@ -172,98 +157,247 @@ type AccessAccessor interface {
 	SetData([]byte) error
 }
 
-// ComponentReference describes the reference to another component in the registry.
-type ComponentReference struct {
-	ObjectMeta `json:",inline"`
-	// ComponentName describes the remote name of the referenced object
-	ComponentName string `json:"componentName"`
+// Source is the definition of a component's source.
+type Source struct {
+	Name                string `json:"name"`
+	TypedObjectAccessor `json:",inline"`
+	Access              TypedObjectAccessor `json:"access"`
+}
+
+// GetName returns the name of the source.
+func (s Source) GetName() string {
+	return s.Name
+}
+
+// SetName sets the name of the source.
+func (s *Source) SetName(name string) {
+	s.Name = name
+}
+
+// jsonSource is the internal representation of a Source
+// that is used to marshal the Resource.
+type jsonSource struct {
+	Name   string          `json:"name"`
+	Access json.RawMessage `json:"access,omitempty"`
+}
+
+// UnmarshalJSON implements a custom json unmarshal method for a Source.
+func (s *Source) UnmarshalJSON(data []byte) error {
+	var (
+		src     Source
+		jsonSrc jsonSource
+	)
+	if err := json.Unmarshal(data, &jsonSrc); err != nil {
+		return err
+	}
+
+	src.Name = jsonSrc.Name
+	acc, err := UnmarshalAccessAccessor(jsonSrc.Access)
+	if err != nil {
+		return err
+	}
+	src.Access = acc
+
+	var sourceJSON map[string]json.RawMessage
+	if err := json.Unmarshal(data, &sourceJSON); err != nil {
+		return err
+	}
+	// remove already parsed attributes
+	delete(sourceJSON, "access")
+	delete(sourceJSON, "name")
+
+	typedObjectJSONBytes, err := json.Marshal(sourceJSON)
+	if err != nil {
+		return err
+	}
+	src.TypedObjectAccessor, err = UnmarshalTypedObjectAccessor(typedObjectJSONBytes, KnownTypes{}, customCodec, nil)
+	if err != nil {
+		return err
+	}
+	*s = src
+	return err
+}
+
+// MarshalJSON implements a custom json marshal method for a source.
+func (s Source) MarshalJSON() ([]byte, error) {
+	var (
+		raw = map[string]json.RawMessage{}
+		err error
+	)
+
+	raw["name"], err = json.Marshal(s.Name)
+	if err != nil {
+		return nil, err
+	}
+	raw["access"], err = MarshalAccessAccessor(s.Access)
+	if err != nil {
+		return nil, err
+	}
+
+	typedObjJSONBytes, err := MarshalTypedObjectAccessor(s.TypedObjectAccessor, KnownTypes{}, customCodec, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var typedObjectJSON map[string]json.RawMessage
+	if err := json.Unmarshal(typedObjJSONBytes, &typedObjectJSON); err != nil {
+		return nil, err
+	}
+
+	for key, val := range typedObjectJSON {
+		raw[key] = val
+	}
+
+	return json.Marshal(raw)
 }
 
 // Resource describes a resource dependency of a component.
 type Resource struct {
-	// Version must be the same as the version of the containing component.
-	ObjectMeta `json:",inline"`
-	ObjectType `json:",inline"`
+	ObjectMeta          `json:",inline"`
+	TypedObjectAccessor `json:",inline"`
 
 	// Access describes the type specific method to
 	// access the defined resource.
-	Access AccessAccessor `json:"-"`
+	Access TypedObjectAccessor `json:"-"`
 }
 
 // jsonResource is the internal representation of a Resource
 // that is used to marshal the Resource.
 type jsonResource struct {
 	ObjectMeta `json:",inline"`
-	ObjectType `json:",inline"`
 	Access     json.RawMessage `json:"access,omitempty"`
 }
 
 // UnmarshalJSON implements a custom json unmarshal method for a Resource.
 func (r *Resource) UnmarshalJSON(data []byte) error {
+	res := Resource{}
 	jsonRes := &jsonResource{}
 	if err := json.Unmarshal(data, &jsonRes); err != nil {
 		return err
 	}
 
-	resource := &Resource{
-		ObjectMeta: jsonRes.ObjectMeta,
-		ObjectType: jsonRes.ObjectType,
-	}
-
-	accessType := &ObjectType{}
-	if err := json.Unmarshal(jsonRes.Access, accessType); err != nil {
-		return err
-	}
-
-	if err := ValidateAccessType(accessType.GetType()); err != nil {
-		return err
-	}
-
-	var (
-		aType AccessCodec
-		ok    bool
-	)
-	aType, ok = KnownAccessTypes[accessType.GetType()]
-	if !ok {
-		aType = customCodec
-	}
-
-	acc, err := aType.Decode(jsonRes.Access)
+	res.ObjectMeta = jsonRes.ObjectMeta
+	acc, err := UnmarshalAccessAccessor(jsonRes.Access)
 	if err != nil {
 		return err
 	}
+	res.Access = acc
 
-	resource.Access = acc
-	*r = *resource
+	var resourceJSON map[string]json.RawMessage
+	if err := json.Unmarshal(data, &resourceJSON); err != nil {
+		return err
+	}
+	// remove already parsed attributes
+	delete(resourceJSON, "access")
+	delete(resourceJSON, "name")
+	delete(resourceJSON, "version")
+
+	typedObjectJSONBytes, err := json.Marshal(resourceJSON)
+	if err != nil {
+		return err
+	}
+	res.TypedObjectAccessor, err = UnmarshalTypedObjectAccessor(typedObjectJSONBytes, KnownTypes{}, customCodec, nil)
+	if err != nil {
+		return err
+	}
+	*r = res
 	return nil
 }
 
 // MarshalJSON implements a custom json marshal method for a Resource.
 func (r Resource) MarshalJSON() ([]byte, error) {
-	if err := ValidateAccessType(r.Access.GetType()); err != nil {
-		return nil, err
-	}
-
-	var (
-		encoder AccessCodec
-		ok      bool
-	)
-
-	encoder, ok = KnownAccessTypes[r.Access.GetType()]
-	if !ok {
-		encoder = customCodec
-	}
-
-	acc, err := encoder.Encode(r.Access)
+	acc, err := MarshalAccessAccessor(r.Access)
 	if err != nil {
 		return nil, err
 	}
 
 	jsonRes := jsonResource{
 		ObjectMeta: r.ObjectMeta,
-		ObjectType: r.ObjectType,
 		Access:     acc,
 	}
 
+	var resourceJSON = map[string]json.RawMessage{}
+	if err := remarshal(jsonRes, &resourceJSON); err != nil {
+		return nil, err
+	}
+
+	typedObjJSONBytes, err := MarshalTypedObjectAccessor(r.TypedObjectAccessor, KnownTypes{}, customCodec, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var typedObjectJSON map[string]json.RawMessage
+	if err := json.Unmarshal(typedObjJSONBytes, &typedObjectJSON); err != nil {
+		return nil, err
+	}
+
+	for key, val := range typedObjectJSON {
+		resourceJSON[key] = val
+	}
 	return json.Marshal(jsonRes)
+}
+
+// UnmarshalTypedObjectAccessor unmarshals a type object into a valid json.
+// The given known types are used to decode the data into a specific.
+// The given defaultCodec is used if no matching type is known.
+// An error is returned when the type is unknown and the default codec is nil.
+func UnmarshalTypedObjectAccessor(data []byte, knownTypes KnownTypes, defaultCodec TypedObjectCodec, validationFunc KnownTypeValidationFunc) (TypedObjectAccessor, error) {
+	accessType := &ObjectType{}
+	if err := json.Unmarshal(data, accessType); err != nil {
+		return nil, err
+	}
+
+	if validationFunc != nil {
+		if err := validationFunc(accessType.GetType()); err != nil {
+			return nil, err
+		}
+	}
+
+	codec, ok := knownTypes[accessType.GetType()]
+	if !ok {
+		codec = defaultCodec
+	}
+
+	acc, err := codec.Decode(data)
+	if err != nil {
+		return nil, err
+	}
+	return acc, nil
+}
+
+// MarshalTypedObjectAccessor marshals a type object into a valid json.
+// The given known types are used to decode the data into a specific.
+// The given defaultCodec is used if no matching type is known.
+// An error is returned when the type is unknown and the default codec is nil.
+func MarshalTypedObjectAccessor(acc TypedObjectAccessor, knownTypes KnownTypes, defaultCodec TypedObjectCodec, validationFunc KnownTypeValidationFunc) ([]byte, error) {
+	if validationFunc != nil {
+		if err := validationFunc(acc.GetType()); err != nil {
+			return nil, err
+		}
+	}
+
+	codec, ok := knownTypes[acc.GetType()]
+	if !ok {
+		codec = defaultCodec
+	}
+
+	return codec.Encode(acc)
+}
+
+// UnmarshalAccessAccessor unmarshals a json access accessor into a known go struct.
+func UnmarshalAccessAccessor(data []byte) (TypedObjectAccessor, error) {
+	return UnmarshalTypedObjectAccessor(data, KnownAccessTypes, customCodec, ValidateAccessType)
+}
+
+// MarshalAccessAccessor marshals a known access accessor into a valid json
+func MarshalAccessAccessor(acc TypedObjectAccessor) ([]byte, error) {
+	return MarshalTypedObjectAccessor(acc, KnownAccessTypes, customCodec, ValidateAccessType)
+}
+
+func remarshal(src, dst interface{}) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dst)
 }

--- a/bindings-go/apis/v2/default.go
+++ b/bindings-go/apis/v2/default.go
@@ -17,7 +17,7 @@ package v2
 // DefaultComponent applies defaults to a component
 func DefaultComponent(component *ComponentDescriptor) error {
 	if component.Sources == nil {
-		component.Sources = make([]Resource, 0)
+		component.Sources = make([]Source, 0)
 	}
 	if component.ComponentReferences == nil {
 		component.ComponentReferences = make([]ComponentReference, 0)

--- a/bindings-go/apis/v2/validation/validation_test.go
+++ b/bindings-go/apis/v2/validation/validation_test.go
@@ -53,10 +53,8 @@ var _ = Describe("Validation", func() {
 				Name:    "image1",
 				Version: "1.2.3",
 			},
-			ObjectType: v2.ObjectType{
-				Type: v2.OCIImageType,
-			},
-			Access: ociRegistry1,
+			TypedObjectAccessor: v2.NewTypeOnly(v2.OCIImageType),
+			Access:              ociRegistry1,
 		}
 		ociRegistry2 = &v2.OCIRegistryAccess{
 			ObjectType: v2.ObjectType{
@@ -69,10 +67,8 @@ var _ = Describe("Validation", func() {
 				Name:    "image2",
 				Version: "1.2.3",
 			},
-			ObjectType: v2.ObjectType{
-				Type: v2.OCIImageType,
-			},
-			Access: ociRegistry2,
+			TypedObjectAccessor: v2.NewTypeOnly(v2.OCIImageType),
+			Access:              ociRegistry2,
 		}
 
 		comp = &v2.ComponentDescriptor{
@@ -271,6 +267,7 @@ var _ = Describe("Validation", func() {
 						Name:    "locRes",
 						Version: "0.0.1",
 					},
+					TypedObjectAccessor: v2.NewTypeOnly(v2.OCIImageType),
 				},
 			}
 			errList := validate(nil, comp)

--- a/bindings-go/codec/codec_suite_test.go
+++ b/bindings-go/codec/codec_suite_test.go
@@ -47,7 +47,7 @@ var _ = Describe("serializer", func() {
 		extDep := comp.ExternalResources[0]
 		Expect(extDep.Name).To(Equal("grafana"))
 		Expect(extDep.Version).To(Equal("7.0.3"))
-		Expect(extDep.Type).To(Equal(v2.OCIImageType))
+		Expect(extDep.GetType()).To(Equal(v2.OCIImageType))
 		Expect(extDep.Access).To(BeAssignableToTypeOf(&v2.OCIRegistryAccess{}))
 
 		ociAccess := extDep.Access.(*v2.OCIRegistryAccess)

--- a/bindings-go/examples/custom/main.go
+++ b/bindings-go/examples/custom/main.go
@@ -62,7 +62,7 @@ component:
 	res, err := component.GetLocalResource("custom1", "ftpRes", "v1.7.2")
 	check(err)
 	// unknown types are serialized as custom type
-	ftpAccess := res.Access.(*v2.CustomAccess)
+	ftpAccess := res.Access.(*v2.CustomType)
 	fmt.Println(ftpAccess.Data["url"]) // prints: ftp://example.com/my-resource
 
 	res, err = component.GetExternalResource("nodeModule", "nodeMod", "0.0.1")
@@ -86,7 +86,7 @@ type NPMAccess struct {
 	Version    string `json:"version"`
 }
 
-var _ v2.AccessAccessor = &NPMAccess{}
+var _ v2.TypedObjectAccessor = &NPMAccess{}
 
 func (n NPMAccess) GetData() ([]byte, error) {
 	return json.Marshal(n)
@@ -103,15 +103,15 @@ func (n *NPMAccess) SetData(bytes []byte) error {
 	return nil
 }
 
-var npmCodec = &v2.AccessCodecWrapper{
-	AccessDecoder: v2.AccessDecoderFunc(func(data []byte) (v2.AccessAccessor, error) {
+var npmCodec = &v2.TypedObjectCodecWrapper{
+	TypedObjectDecoder: v2.TypedObjectDecoderFunc(func(data []byte) (v2.TypedObjectAccessor, error) {
 		var npm NPMAccess
 		if err := json.Unmarshal(data, &npm); err != nil {
 			return nil, err
 		}
 		return &npm, nil
 	}),
-	AccessEncoder: v2.AccessEncoderFunc(func(accessor v2.AccessAccessor) ([]byte, error) {
+	TypedObjectEncoder: v2.TypedObjectEncoderFunc(func(accessor v2.TypedObjectAccessor) ([]byte, error) {
 		npm, ok := accessor.(*NPMAccess)
 		if !ok {
 			return nil, fmt.Errorf("accessor is not of type %s", NPMType)

--- a/bindings-go/examples/main.go
+++ b/bindings-go/examples/main.go
@@ -68,7 +68,7 @@ component:
 	fmt.Printf("%v\n", res)
 
 	// get the access for a resource
-	// known types implement the AccessAccessor interface and can be cast to the specific type.
+	// known types implement the TypedObjectAccessor interface and can be cast to the specific type.
 	ociAccess := res.Access.(*v2.OCIRegistryAccess)
 	fmt.Println(ociAccess.ImageReference) // prints: eu.gcr.io/gardener-project/gardener/apiserver:v1.7.2
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the current go test by now allowing additional attributes for resources and sources.
The validator does now also not enforce a version for a source.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
