### PR TITLE
add (optional) src-refs

### DIFF
--- a/component-descriptor-v2-schema.yaml
+++ b/component-descriptor-v2-schema.yaml
@@ -24,7 +24,6 @@ definitions:
         type: 'string'
     additionalProperties: False
 
-
   repositoryContext:
     type: 'object'
     required:
@@ -91,6 +90,17 @@ definitions:
           - $ref: '#/definitions/githubAccess'
           - $ref: '#/definitions/httpAccess'
 
+  srcRef:
+    type: 'object'
+    description: 'a reference to a (component-local) source'
+    properties:
+      identitySelector:
+        $ref: '#/definitions/identityAttribute'
+      labels:
+        type: 'array'
+        items:
+          $ref: '#/definitions/label'
+
   componentReference:
     type: 'object'
     description: 'a reference to a component'
@@ -128,6 +138,10 @@ definitions:
         type: 'string'
       type:
         type: 'string'
+      srcRefs:
+        type: 'array'
+        items:
+          $ref: '#/definitions/srcRef'
       relation:
         type: 'string'
         enum: ['local', 'external']


### PR DESCRIPTION
In some cases, it is a valueable metadata to know which components stem
from which sources. Add an optional src-refs attribute to resources that
allows to express this relationship.

Add an optional `labels` attribute to src-refs, to allow for the
specification of additional metadata (e.g. a subset of actually relevant
sources).