### PR TITLE
Fix type of default value

### DIFF
--- a/bindings-python/gci/componentmodel.py
+++ b/bindings-python/gci/componentmodel.py
@@ -222,7 +222,7 @@ class ComponentReference(Artifact, FindLabelMixin):
     name: str
     componentName: str
     version: str
-    extraIdentity: typing.Dict[str, str] = dataclasses.field(default_factory=tuple)
+    extraIdentity: typing.Dict[str, str] = dataclasses.field(default_factory=dict)
     labels: typing.List[Label] = dataclasses.field(default_factory=tuple)
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes/changes type of default value of ComponentReference's `extraIdentity` field to dict.
**Which issue(s) this PR fixes**:
PyYaml serializes tuples to yaml-lists, which causes an issue when trying to de-serialize the cd again as dacite detects a type mismatch.