### PR TITLE
fix extra identity getter for component references

### DIFF
--- a/bindings-go/apis/v2/componentdescriptor.go
+++ b/bindings-go/apis/v2/componentdescriptor.go
@@ -474,8 +474,8 @@ func (o *ComponentReference) SetLabels(labels []Label) {
 // GetLabels returns the identity of the object.
 func (o *ComponentReference) GetIdentity() Identity {
 	identity := map[string]string{}
-	if o.ExtraIdentity != nil {
-		identity = o.ExtraIdentity
+	for k, v := range o.ExtraIdentity {
+		identity[k] = v
 	}
 	identity[SystemIdentityName] = o.Name
 	return identity


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the extra identity attribute getter for component references

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
