### PR TITLE
add helper functions for image references

### DIFF
--- a/bindings-go/apis/v2/cdutils/cdutils_suite_test.go
+++ b/bindings-go/apis/v2/cdutils/cdutils_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cdutils Test Suite")
+}

--- a/bindings-go/apis/v2/cdutils/resource_test.go
+++ b/bindings-go/apis/v2/cdutils/resource_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdutils_test
+
+import (
+	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/apis/v2/cdutils"
+	"github.com/gardener/component-spec/bindings-go/codec"
+)
+
+var _ = Describe("resource utils", func() {
+
+	Context("#GetImageReferenceFromList", func() {
+		It("should return the image from a component descriptor list", func() {
+			data, err := ioutil.ReadFile("../../../../language-independent/test-resources/component_descriptor_v2.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			cd := cdv2.ComponentDescriptor{}
+			Expect(codec.Decode(data, &cd)).To(Succeed())
+
+			imageAccess, err := cdutils.GetImageReferenceFromList(
+				&cdv2.ComponentDescriptorList{Components: []cdv2.ComponentDescriptor{cd}},
+				"github.com/gardener/gardener", "apiserver")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(imageAccess).To(Equal("eu.gcr.io/gardener-project/gardener/apiserver:v1.7.4"))
+		})
+
+		It("should return an error if no component matches the given name", func() {
+			data, err := ioutil.ReadFile("../../../../language-independent/test-resources/component_descriptor_v2.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			cd := cdv2.ComponentDescriptor{}
+			Expect(codec.Decode(data, &cd)).To(Succeed())
+
+			_, err = cdutils.GetImageReferenceFromList(
+				&cdv2.ComponentDescriptorList{Components: []cdv2.ComponentDescriptor{cd}},
+				"github.com/gardener/nocomp", "apiserver")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("#GetImageReferenceByName", func() {
+		It("should return the image from a component descriptor", func() {
+			data, err := ioutil.ReadFile("../../../../language-independent/test-resources/component_descriptor_v2.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			cd := &cdv2.ComponentDescriptor{}
+			Expect(codec.Decode(data, cd)).To(Succeed())
+
+			imageAccess, err := cdutils.GetImageReferenceByName(cd, "apiserver")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(imageAccess).To(Equal("eu.gcr.io/gardener-project/gardener/apiserver:v1.7.4"))
+		})
+
+		It("should return an error if no resource matches the given name", func() {
+			data, err := ioutil.ReadFile("../../../../language-independent/test-resources/component_descriptor_v2.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			cd := &cdv2.ComponentDescriptor{}
+			Expect(codec.Decode(data, cd)).To(Succeed())
+
+			_, err = cdutils.GetImageReferenceByName(cd, "noimage")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+})

--- a/bindings-go/apis/v2/cdutils/resources.go
+++ b/bindings-go/apis/v2/cdutils/resources.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdutils
+
+import (
+	"fmt"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+// GetImageReferenceFromList returns the image reference of a resource with the given name from a component descriptor.
+// If the component name and resource name is not unique the first found object is used.
+func GetImageReferenceFromList(cdList *cdv2.ComponentDescriptorList, componentName, resourceName string) (string, error) {
+	components := cdList.GetComponentByName(componentName)
+	if len(components) == 0 {
+		return "", fmt.Errorf("no copmponent with name %q found", componentName)
+	}
+	cd := components[0]
+	return GetImageReferenceByName(&cd, resourceName)
+}
+
+// GetImageReferenceByName returns the image reference of a resource with the given name from a component descriptor.
+func GetImageReferenceByName(cd *cdv2.ComponentDescriptor, name string) (string, error) {
+	resources, err := cd.GetResourcesByName(name)
+	if err != nil {
+		return "", err
+	}
+	res := resources[0]
+	if res.Access.GetType() != cdv2.OCIRegistryType {
+		return "", fmt.Errorf("resource is expected to be of type %q but is of type %q", cdv2.OCIRegistryType, res.Access.GetType())
+	}
+
+	data, err := res.Access.GetData()
+	if err != nil {
+		return "", err
+	}
+	ociImageAccess := &cdv2.OCIRegistryAccess{}
+	if err := cdv2.NewDefaultCodec().Decode(data, ociImageAccess); err != nil {
+		return "", err
+	}
+	return ociImageAccess.ImageReference, nil
+}

--- a/bindings-go/apis/v2/codecs.go
+++ b/bindings-go/apis/v2/codecs.go
@@ -121,6 +121,15 @@ type codec struct {
 	validationFunc KnownTypeValidationFunc
 }
 
+// NewDefaultCodec creates a new default typed object codec.
+func NewDefaultCodec() TypedObjectCodec {
+	return &codec{
+		defaultCodec: DefaultJSONTypedObjectCodec,
+		knownTypes:   KnownAccessTypes,
+	}
+}
+
+// NewCodec creates a new typed object codec.
 func NewCodec(knownTypes KnownTypes, defaultCodec TypedObjectCodec, validationFunc KnownTypeValidationFunc) TypedObjectCodec {
 	if knownTypes == nil {
 		knownTypes = KnownAccessTypes

--- a/bindings-go/go.mod
+++ b/bindings-go/go.mod
@@ -16,4 +16,5 @@ require (
 	golang.org/x/sys v0.0.0-20200806060901-a37d78b92225 // indirect
 	k8s.io/apimachinery v0.18.6
 	k8s.io/code-generator v0.18.2
+	sigs.k8s.io/yaml v1.2.0
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

added helper functions for image reference access.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @danielfoehrKn 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
