### PR TITLE
Add utility function to get image repo and tag from image reference

### DIFF
--- a/bindings-go/apis/v2/cdutils/resource_test.go
+++ b/bindings-go/apis/v2/cdutils/resource_test.go
@@ -68,4 +68,42 @@ var _ = Describe("resource utils", func() {
 		})
 	})
 
+	Context("#GetRepositoryAndTagFromReference", func() {
+		It("should return the repository and tag", func() {
+			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io/gardener-project/gardener/apiserver:v1.7.4")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(repo).To(Equal("eu.gcr.io/gardener-project/gardener/apiserver"))
+			Expect(tag).To(Equal("v1.7.4"))
+		})
+
+		It("should return the repository and tag - image reference contains port", func() {
+			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io:5000/gardener-project/gardener/apiserver:v1.7.4")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(repo).To(Equal("eu.gcr.io:5000/gardener-project/gardener/apiserver"))
+			Expect(tag).To(Equal("v1.7.4"))
+		})
+
+		It("should return the repository and tag - image reference contains a SHA256", func() {
+			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io/gardener-project/apiserver@sha256:12345")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(repo).To(Equal("eu.gcr.io/gardener-project/apiserver"))
+			Expect(tag).To(Equal("sha256:12345"))
+		})
+
+		It("should return the repository and tag - image reference contains a SHA256 and port", func() {
+			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io:5000/gardener-project/apiserver@sha256:12345")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(repo).To(Equal("eu.gcr.io:5000/gardener-project/apiserver"))
+			Expect(tag).To(Equal("sha256:12345"))
+		})
+
+		It("should return an error - the image reference is invalid", func() {
+			_, _, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io/gardener-project/gardenerapiserver--v1.7.4")
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/bindings-go/apis/v2/cdutils/resources.go
+++ b/bindings-go/apis/v2/cdutils/resources.go
@@ -6,6 +6,7 @@ package cdutils
 
 import (
 	"fmt"
+	"strings"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 )
@@ -41,4 +42,29 @@ func GetImageReferenceByName(cd *cdv2.ComponentDescriptor, name string) (string,
 		return "", err
 	}
 	return ociImageAccess.ImageReference, nil
+}
+
+// GetRepositoryAndTagFromReference takes an image reference
+// e.g eu.gcr.io/gardener-project/gardener/gardenlet:v1.11.3
+// and returns the image repository as a first, and the tag as a second argument
+func GetRepositoryAndTagFromReference(imageReference string) (string, string, error) {
+	if strings.Contains(imageReference, "@") {
+		split := strings.Split(imageReference, "@")
+		if len(split) != 2 {
+			return "", "", fmt.Errorf("failed to parse image respository and tag from image reference %q", imageReference)
+		}
+		return split[0], split[1], nil
+	}
+
+	split := strings.Split(imageReference, ":")
+	if len(split) == 2 {
+		return split[0], split[1], nil
+	}
+
+	// split version from reference if image reference contains a port
+	// e.g eu.gcr.io:5000/gardener-project/gardener/gardenlet
+	if len(split) == 3 {
+		return fmt.Sprintf("%s:%s", split[0], split[1]), split[2], nil
+	}
+	return "", "", fmt.Errorf("failed to parse image respository and tag from image reference %q", imageReference)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding a simple utility function to get image repo and tag from an image reference.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
