### PR TITLE
Rename and fix GetRepositoryAndTagFromReference util function

### DIFF
--- a/bindings-go/apis/v2/cdutils/resource_test.go
+++ b/bindings-go/apis/v2/cdutils/resource_test.go
@@ -68,41 +68,45 @@ var _ = Describe("resource utils", func() {
 		})
 	})
 
-	Context("#GetRepositoryAndTagFromReference", func() {
+	Context("#ParseImageReference", func() {
 		It("should return the repository and tag", func() {
-			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io/gardener-project/gardener/apiserver:v1.7.4")
+			repo, tag, seperator, err := cdutils.ParseImageReference("eu.gcr.io/gardener-project/gardener/apiserver:v1.7.4")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(repo).To(Equal("eu.gcr.io/gardener-project/gardener/apiserver"))
 			Expect(tag).To(Equal("v1.7.4"))
+			Expect(seperator).To(Equal(":"))
 		})
 
 		It("should return the repository and tag - image reference contains port", func() {
-			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io:5000/gardener-project/gardener/apiserver:v1.7.4")
+			repo, tag, seperator, err := cdutils.ParseImageReference("eu.gcr.io:5000/gardener-project/gardener/apiserver:v1.7.4")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(repo).To(Equal("eu.gcr.io:5000/gardener-project/gardener/apiserver"))
 			Expect(tag).To(Equal("v1.7.4"))
+			Expect(seperator).To(Equal(":"))
 		})
 
 		It("should return the repository and tag - image reference contains a SHA256", func() {
-			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io/gardener-project/apiserver@sha256:12345")
+			repo, sha, seperator, err := cdutils.ParseImageReference("eu.gcr.io/gardener-project/apiserver@sha256:12345")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(repo).To(Equal("eu.gcr.io/gardener-project/apiserver"))
-			Expect(tag).To(Equal("sha256:12345"))
+			Expect(sha).To(Equal("sha256:12345"))
+			Expect(seperator).To(Equal("@"))
 		})
 
 		It("should return the repository and tag - image reference contains a SHA256 and port", func() {
-			repo, tag, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io:5000/gardener-project/apiserver@sha256:12345")
+			repo, sha, seperator, err := cdutils.ParseImageReference("eu.gcr.io:5000/gardener-project/apiserver@sha256:12345")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(repo).To(Equal("eu.gcr.io:5000/gardener-project/apiserver"))
-			Expect(tag).To(Equal("sha256:12345"))
+			Expect(sha).To(Equal("sha256:12345"))
+			Expect(seperator).To(Equal("@"))
 		})
 
 		It("should return an error - the image reference is invalid", func() {
-			_, _, err := cdutils.GetRepositoryAndTagFromReference("eu.gcr.io/gardener-project/gardenerapiserver--v1.7.4")
+			_, _, _, err := cdutils.ParseImageReference("eu.gcr.io/gardener-project/gardenerapiserver--v1.7.4")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/bindings-go/apis/v2/cdutils/resources.go
+++ b/bindings-go/apis/v2/cdutils/resources.go
@@ -44,27 +44,30 @@ func GetImageReferenceByName(cd *cdv2.ComponentDescriptor, name string) (string,
 	return ociImageAccess.ImageReference, nil
 }
 
-// GetRepositoryAndTagFromReference takes an image reference
+// ParseImageReference takes an image reference
 // e.g eu.gcr.io/gardener-project/gardener/gardenlet:v1.11.3
-// and returns the image repository as a first, and the tag as a second argument
-func GetRepositoryAndTagFromReference(imageReference string) (string, string, error) {
+// returns
+// first argument: the image repository
+// second argument: the tag or the SHA256
+// third argument: the separator (either ":" when it is a tag or "@" if it is a SHA256)
+func ParseImageReference(imageReference string) (string, string, string, error) {
 	if strings.Contains(imageReference, "@") {
 		split := strings.Split(imageReference, "@")
 		if len(split) != 2 {
-			return "", "", fmt.Errorf("failed to parse image respository and tag from image reference %q", imageReference)
+			return "", "", "", fmt.Errorf("failed to parse image respository and tag from image reference %q", imageReference)
 		}
-		return split[0], split[1], nil
+		return split[0], split[1], "@", nil
 	}
 
 	split := strings.Split(imageReference, ":")
 	if len(split) == 2 {
-		return split[0], split[1], nil
+		return split[0], split[1], ":", nil
 	}
 
 	// split version from reference if image reference contains a port
 	// e.g eu.gcr.io:5000/gardener-project/gardener/gardenlet
 	if len(split) == 3 {
-		return fmt.Sprintf("%s:%s", split[0], split[1]), split[2], nil
+		return fmt.Sprintf("%s:%s", split[0], split[1]), split[2], ":", nil
 	}
-	return "", "", fmt.Errorf("failed to parse image respository and tag from image reference %q", imageReference)
+	return "", "", "", fmt.Errorf("failed to parse image respository and tag from image reference %q", imageReference)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Renamed to `ParseImageReference` and returns the separator as a third argument.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
