### PR TITLE
add optional component-name-mapping to repository-ctx

### DIFF
--- a/doc/component_descriptor_registries.rst
+++ b/doc/component_descriptor_registries.rst
@@ -18,6 +18,26 @@ URL *MUST* refer to an OCI Image Registry (for example `eu.gcr.io/gardener-proje
 
 The base URL *MAY* refer to sub-path on a OCI Image Registry.
 
+The thus-referenced `Component Descriptor` is stored as an OCI Container Image would be. The
+Image Manifest *MUST* contain exactly one layer. The layer *MUST* be a POSIX.1-2001-compliant
+pax archive (commonly also known as "tarball"), containing as first entry a regular file named
+`component-descriptor.yaml`, whose `utf-8`-encoded content is a valid `Component Descriptor` (v2),
+serialised as either YAML or JSON.
+
+Component Name Mapping
+~~~~~~~~~~~~~~~~~~~~~~
+
+Any OCI Image Registry used as a Component Descriptor registry *MUST* define an unambiguous
+mapping of `Component Name`, `Component Version`-tuples to OCI Image References.
+
+The following Component Name mappings are known:
+
+- urlPath
+- sha256-digest
+
+Component Name Mapping `urlPath`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Component Descriptor OCI Names are constructed like so:
 
 `<baseUrl>/componentDescriptors/<componentName>:<versionTag>`
@@ -28,8 +48,16 @@ Where:
 - componentName is a valid `Component Name` (i.e. a domain name with an optional URL path suffix)
 - versionTag is a valid `Component Version` (i.e. relaxed semver version)
 
-The thus-referenced `Component Descriptor` is stored as an OCI Container Image would be. The
-Image Manifest *MUST* contain exactly one layer. The layer *MUST* be a POSIX.1-2001-compliant
-pax archive (commonly also known as "tarball"), containing as first entry a regular file named
-`component-descriptor.yaml`, whose `utf-8`-encoded content is a valid `Component Descriptor` (v2),
-serialised as either YAML or JSON.
+
+Component Name Mapping `sha256-digest`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Component Descriptor OCI Names are constructed like so:
+
+`<baseUrl>/<componentNameDigest>:<versionTag>`
+
+Where:
+
+- baseUrl is the already-discussed registry URL
+- ComponentName is the lowercased hexadecimal sha256-digest of the utf-8-encoded `Component Name`
+- versionTag is a valid `Component Version` (i.e. relaxed semver version)

--- a/language-independent/component-descriptor-v2-schema.yaml
+++ b/language-independent/component-descriptor-v2-schema.yaml
@@ -47,14 +47,25 @@ definitions:
   repositoryContext:
     type: 'object'
     required:
-      - 'baseUrl'
       - 'type'
     properties:
-      baseUrl:
-        type: 'string'
       type:
         type: 'string'
-        enum: ['ociRegistry']
+
+  ociRepositoryContext:
+    allOf:
+      - $ref: '#/definitions/repositoryContext'
+      - required:
+        - 'baseUrl'
+        properties:
+          baseUrl:
+            type: 'string'
+          componentNameMapping:
+            type: 'string'
+            enum: ['urlPath', 'sha256-digest']
+          type:
+            type: 'string'
+            enum: ['ociRegistry']
 
   access:
     type: 'object'
@@ -341,7 +352,8 @@ definitions:
       repositoryContexts:
         type: 'array'
         items:
-          $ref: '#/definitions/repositoryContext'
+          anyOf:
+            - $ref: '#/definitions/ociRepositoryContext' # currently, we only allow this one
       provider:
         type: 'string'
         enum: ['internal', 'external']


### PR DESCRIPTION
There are, unfortunately, OCI-Registries that do not support arbitrary
image-name-paths (e.g. docker-hub, registry.alicloud). Also, there are
retrictions as to the maximum allowed name-length (currently known for
registry.alicloud).

Add a new attribute specifying how component-names be mapped to
oci-artifacts, with a hash-digest-variant as an alternative to using the
original component-name.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
