### PR TITLE
Define version-attribute type in referenced config

### DIFF
--- a/language-independent/component-descriptor-v2-schema.yaml
+++ b/language-independent/component-descriptor-v2-schema.yaml
@@ -39,6 +39,7 @@ definitions:
     # v1.2
     # v1-foo+bar
     pattern: '^[v]?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+    type: 'string'
 
   identityAttribute:
     type: 'object'
@@ -113,7 +114,6 @@ definitions:
       extraIdentity:
         $ref: '#/definitions/identityAttribute'
       version:
-        type: 'string'
         $ref: '#/definitions/relaxedSemver'
       type:
         type: 'string'
@@ -155,7 +155,6 @@ definitions:
       extraIdentity:
         $ref: '#/definitions/identityAttribute'
       version:
-        type: 'string'
         $ref: '#/definitions/relaxedSemver'
       labels:
         type: 'array'
@@ -273,7 +272,6 @@ definitions:
       extraIdentity:
         $ref: '#/definitions/identityAttribute'
       version:
-        type: 'string'
         $ref: '#/definitions/relaxedSemver'
       type:
         type: 'string'
@@ -320,7 +318,6 @@ definitions:
       extraIdentity:
         $ref: '#/definitions/identityAttribute'
       version:
-        type: 'string'
         $ref: '#/definitions/relaxedSemver'
       type:
         type: 'string'
@@ -347,7 +344,6 @@ definitions:
       name:
         $ref: '#/definitions/componentName'
       version:
-        type: 'string'
         $ref: '#/definitions/relaxedSemver'
       repositoryContexts:
         type: 'array'


### PR DESCRIPTION
Python validation will not detect an illegal `None` as version otherwise. 

For a basic reproducer, you can use the following CD:

```yaml
component:
  componentReferences: []
  labels: []
  name: github.com/gardener/aws-lb-readvertiser
  provider: internal
  repositoryContexts:
  - baseUrl: eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development
    type: ociRegistry
  resources:
  - access:
      imageReference: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser:0.7.0
      type: ociRegistry
    extraIdentity: {}
    labels: []
    name: aws-lb-readvertiser
    relation: local
    srcRefs: []
    type: ociImage
    version: 0.7.0
  sources:
  - access:
      commit: a66fff3ba92bad9132419266cfbd1c58fd51a7d2
      ref: refs/tags/0.7.0
      repoUrl: github.com/gardener/aws-lb-readvertiser
      type: github
    extraIdentity: {}
    labels: []
    name: aws-lb-readvertiser
    type: git
    version: null
  version: 0.7.0
meta:
  schemaVersion: v2
```

As its `component.sources[0].version` is `null`, it will be parsed to `None`. `None` is not a string and thus validation should fail, yet the current code will accept it without complaint.

Note: The descriptor posted above _can_, however, be parsed as a CD since we allow `None` as version-value for backwards-compatibility. 