### PR TITLE
passes through component descriptor decode options

### DIFF
--- a/bindings-go/ctf/componentarchive.go
+++ b/bindings-go/ctf/componentarchive.go
@@ -32,7 +32,7 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/opencontainers/go-digest"
 
-	"github.com/gardener/component-spec/bindings-go/apis/v2"
+	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/codec"
 )
 
@@ -97,13 +97,13 @@ func NewComponentArchiveFromTarReader(in io.Reader) (*ComponentArchive, error) {
 }
 
 // NewComponentArchiveFromFilesystem creates a new component archive from a filesystem.
-func NewComponentArchiveFromFilesystem(fs vfs.FileSystem) (*ComponentArchive, error) {
+func NewComponentArchiveFromFilesystem(fs vfs.FileSystem, decodeOpts ...codec.DecodeOption) (*ComponentArchive, error) {
 	data, err := vfs.ReadFile(fs, filepath.Join("/", ComponentDescriptorFileName))
 	if err != nil {
 		return nil, fmt.Errorf("unable to read the component descriptor from %s: %w", ComponentDescriptorFileName, err)
 	}
 	cd := &v2.ComponentDescriptor{}
-	if err := codec.Decode(data, cd); err != nil {
+	if err := codec.Decode(data, cd, decodeOpts...); err != nil {
 		return nil, fmt.Errorf("unable to parse component descriptor read from %s: %w", ComponentDescriptorFileName, err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
passes through decode options when loading a component archive. feature is needed as we must be able to disable validation when loading invalid components descriptors (e.g. where some fields are not yet set) in the component cli.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
