### PR TITLE
Fix URL typo in 'Building Components' doc

### DIFF
--- a/doc/building_components.rst
+++ b/doc/building_components.rst
@@ -7,7 +7,7 @@ About those build processes, the CNUDIE Component Descriptor model also does not
 assumptions.
 
 To make generating Component Descriptors more convenient, there is a re-usable toolset that can
-be used (`<https://gitub.com/gardener/component-cli>`_).
+be used (`<https://github.com/gardener/component-cli>`_).
 
 The following example shows how this can be done based on a `make`-based build.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo in the docs.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:   user
-->
```improvement operator
NONE
```
