### PR TITLE
Fix merge labels

### DIFF
--- a/bindings-go/apis/v2/cdutils/utils.go
+++ b/bindings-go/apis/v2/cdutils/utils.go
@@ -50,7 +50,7 @@ func MergeIdentityObjectMeta(a, b v2.IdentityObjectMeta) v2.IdentityObjectMeta {
 	}
 
 	for _, label := range b.Labels {
-		if idx := GetLabelIdx(b.Labels, label.Name); idx != -1 {
+		if idx := GetLabelIdx(a.Labels, label.Name); idx != -1 {
 			a.Labels[idx] = label
 		} else {
 			a.Labels = append(a.Labels, label)

--- a/bindings-go/apis/v2/cdutils/utils_test.go
+++ b/bindings-go/apis/v2/cdutils/utils_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdutils
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+var _ = Describe("resource utils", func() {
+
+	Context("#MergeIdentityObjectMeta", func() {
+
+		It("should merge labels", func() {
+			meta1 := cdv2.IdentityObjectMeta{
+				Name: "test",
+				Labels: cdv2.Labels{
+					{Name: "k2", Value: []byte("v2")},
+					{Name: "k3", Value: []byte("xx")},
+				},
+			}
+			meta2 := cdv2.IdentityObjectMeta{
+				Name: "test",
+				Labels: cdv2.Labels{
+					{Name: "k1", Value: []byte("v1")},
+					{Name: "k3", Value: []byte("v3")},
+					{Name: "k4", Value: []byte("v4")},
+				},
+			}
+
+			result := MergeIdentityObjectMeta(meta1, meta2)
+			Expect(result.Labels).To(ConsistOf(
+				cdv2.Label{Name: "k1", Value: []byte("v1")},
+				cdv2.Label{Name: "k2", Value: []byte("v2")},
+				cdv2.Label{Name: "k3", Value: []byte("v3")},
+				cdv2.Label{Name: "k4", Value: []byte("v4")},
+			))
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request fixes function `cdutils.MergeIdentityObjectMeta`. Among others, the function merges two slices of Labels, but has the following issues:

- It panics if the second slice of Labels is longer than the first,
- Depending on the order of the labels, it replaces the wrong label.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
