### PR TITLE
Add signing fields to component descriptor schema

### DIFF
--- a/doc/proposal/component-descriptor-v2-schema.yaml
+++ b/doc/proposal/component-descriptor-v2-schema.yaml
@@ -63,6 +63,49 @@ definitions:
       type:
         type: 'string'
 
+  digestSpec:
+    type: 'object'
+    required:
+      - hashAlgorithm
+      - normalisationAlgorithm
+      - value
+    properties:
+      hashAlgorithm:
+        type: string
+      normalisationAlgorithm:
+        type: string
+      value:
+        type: string
+
+  signatureSpec:
+    type: 'object'
+    required:
+      - algorithm
+      - value
+      - mediaType
+    properties:
+      algorithm:
+        type: string
+      value:
+        type: string
+      mediaType:
+        description: 'The media type of the signature value'
+        type: string
+
+  signature:
+    type: 'object'
+    required:
+      - name
+      - digest
+      - signature
+    properties:
+      name:
+        type: string
+      digest:
+        $ref: '#/definitions/digestSpec'
+      signature:
+        $ref: '#/definitions/signatureSpec'
+
   source:
     type: 'object'
     required:
@@ -110,6 +153,10 @@ definitions:
         type: 'array'
         items:
           $ref: '#/definitions/label'
+      digest:
+        oneOf:
+          - type: 'null'
+          - $ref: '#/definitions/digestSpec'
 
   resource:
     type: 'object'
@@ -145,6 +192,10 @@ definitions:
         anyOf:
         - $ref: '#/definitions/access'
         - $ref: '#/definitions/localBlobAccess'
+      digest:
+        oneOf:
+          - type: 'null'
+          - $ref: '#/definitions/digestSpec'
 
   srcRef:
     type: 'object'
@@ -218,3 +269,7 @@ properties:
     $ref: '#/definitions/meta'
   component:
     $ref: '#/definitions/component'
+  signatures:
+    type: 'array'
+    items:
+      $ref: '#/definitions/signature'


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adjusts the proposal json schema for the component descriptor. 

The field definitions concerning digests and signing are taken over from the current [JSON schema for the component descriptor](https://github.com/gardener/component-spec/blob/master/language-independent/component-descriptor-v2-schema.yaml).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
