### PR TITLE
Add CD struct jsonschema validation

### DIFF
--- a/bindings-go/apis/v2/jsonscheme/jsonscheme.go
+++ b/bindings-go/apis/v2/jsonscheme/jsonscheme.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/xeipuuv/gojsonschema"
+
+	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 )
 
 var Schema *gojsonschema.Schema
@@ -65,4 +67,13 @@ func Validate(src []byte) error {
 	}
 
 	return nil
+}
+
+// ValidateComponentDescriptor validates the given component decriptor against the component descriptor v2 jsonscheme.
+func ValidateComponentDescriptor(cd v2.ComponentDescriptor) error {
+	marshaledCd, err := yaml.Marshal(cd)
+	if err != nil {
+		return fmt.Errorf("failed marshaling cd to yaml: %w", err)
+	}
+	return Validate(marshaledCd)
 }

--- a/bindings-go/apis/v2/validation/validation.go
+++ b/bindings-go/apis/v2/validation/validation.go
@@ -21,10 +21,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/apis/v2/jsonscheme"
 )
 
 // Validate validates a parsed v2 component descriptor
 func Validate(component *v2.ComponentDescriptor) error {
+	if err := jsonscheme.ValidateComponentDescriptor(*component); err != nil {
+		return err
+	}
 	if err := validate(nil, component); err != nil {
 		return err.ToAggregate()
 	}

--- a/bindings-go/apis/v2/validation/validation_test.go
+++ b/bindings-go/apis/v2/validation/validation_test.go
@@ -131,6 +131,14 @@ var _ = Describe("Validation", func() {
 	})
 
 	Context("#ObjectMeta", func() {
+		It("should forbid invalid component name as specified in json schema", func() {
+			comp.Name = "http://example.org/org/name"
+			v2.DefaultComponent(comp)
+			errs := Validate(comp)
+			Expect(errs).To(HaveOccurred())
+			Expect(errs.Error()).To(ContainSubstring("component.name: Does not match pattern"))
+		})
+
 		It("should forbid if the component's version is missing", func() {
 			comp := v2.ComponentDescriptor{}
 			errList := validate(nil, &comp)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the validation func for component-descriptors does not validate against the json schema.
This PR expands the current validation logic with a check against the json schema.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
component-descriptor validation now validates against json schema
```
