### PR TITLE
configurable hash functions

### DIFF
--- a/bindings-go/apis/v2/signatures/const.go
+++ b/bindings-go/apis/v2/signatures/const.go
@@ -17,12 +17,9 @@ package signatures
 import "crypto"
 
 const (
-	NO_HASH = ""
-	SHA256  = "sha256"
+	SHA256 = "sha256"
 )
 
 var HashFunctions = map[string]crypto.Hash{
-	// NO_HASH defines 0 as hash function for signing directly without defining the hash algorithm
-	NO_HASH: crypto.Hash(0),
-	SHA256:  crypto.SHA256,
+	SHA256: crypto.SHA256,
 }

--- a/bindings-go/apis/v2/signatures/const.go
+++ b/bindings-go/apis/v2/signatures/const.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signatures
+
+import "crypto"
+
+const (
+	NO_HASH = ""
+	SHA256  = "sha256"
+)
+
+var HashFunctions = map[string]crypto.Hash{
+	// NO_HASH defines 0 as hash function for signing directly without defining the hash algorithm
+	NO_HASH: crypto.Hash(0),
+	SHA256:  crypto.SHA256,
+}

--- a/bindings-go/apis/v2/signatures/types.go
+++ b/bindings-go/apis/v2/signatures/types.go
@@ -44,8 +44,6 @@ type Hasher struct {
 	AlgorithmName string
 }
 
-const SHA256 = "sha256"
-
 // HasherForName creates a Hasher instance for the algorithmName.
 func HasherForName(algorithmName string) (*Hasher, error) {
 	switch strings.ToLower(algorithmName) {

--- a/bindings-go/apis/v2/signatures/types.go
+++ b/bindings-go/apis/v2/signatures/types.go
@@ -16,10 +16,8 @@ package signatures
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"hash"
-	"strings"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 )
@@ -46,19 +44,15 @@ type Hasher struct {
 
 // HasherForName creates a Hasher instance for the algorithmName.
 func HasherForName(algorithmName string) (*Hasher, error) {
-	switch strings.ToLower(algorithmName) {
-	case SHA256:
-		return &Hasher{
-			HashFunction:  sha256.New(),
-			AlgorithmName: SHA256,
-		}, nil
-	case strings.ToLower(cdv2.NoDigest):
-		return &Hasher{
-			HashFunction:  nil,
-			AlgorithmName: cdv2.NoDigest,
-		}, nil
+	hashfunc, ok := HashFunctions[algorithmName]
+	if !ok {
+		return nil, fmt.Errorf("hash algorithm %s not found/implemented", algorithmName)
 	}
-	return nil, fmt.Errorf("hash algorithm %s not found/implemented", algorithmName)
+
+	return &Hasher{
+		HashFunction:  hashfunc.New(),
+		AlgorithmName: algorithmName,
+	}, nil
 }
 
 type ResourceDigester interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
- makes hash function configurable
- pass in hash function in rsa.Sign() and rsa.Verify() calls instead of passing in 0. this will apply EMSA-PKCS1-v1_5 encoding (https://datatracker.ietf.org/doc/html/rfc3447#section-9.2) before signing the data, which is part of  standard RSASSA-PKCS1-v1_5 (https://datatracker.ietf.org/doc/html/rfc3447#section-8.2). 
**(!) Attention: this change will break existing signatures**

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
- pass in hash function in rsa.Sign() and rsa.Verify() calls instead of passing in 0. this will apply EMSA-PKCS1-v1_5 encoding (https://datatracker.ietf.org/doc/html/rfc3447#section-9.2) before signing the data, which is part of  standard RSASSA-PKCS1-v1_5 (https://datatracker.ietf.org/doc/html/rfc3447#section-8.2). (!) Attention: this change will break existing signatures.
```
